### PR TITLE
refactor: 빌더 및 정적 팩토리 메소드 패턴 사용 검토

### DIFF
--- a/jpashop/src/main/java/jpabook/jpashop/domain/Delivery.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/Delivery.java
@@ -40,10 +40,6 @@ public class Delivery {
         this.status = status;
     }
 
-    public static Delivery createDelivery(final Address address, final DeliveryStatus status) {
-        return new Delivery(address, status);
-    }
-
     public void addOrder(final Order order) {
         this.order = order;
     }

--- a/jpashop/src/main/java/jpabook/jpashop/domain/Member.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/Member.java
@@ -37,11 +37,4 @@ public class Member {
         this.name = name;
         this.address = address;
     }
-
-    public static Member createMember(final String name, final Address address) {
-        return Member.builder()
-                .name(name)
-                .address(address)
-                .build();
-    }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/domain/OrderItem.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/OrderItem.java
@@ -44,15 +44,6 @@ public class OrderItem {
         this.count = count;
     }
 
-    public static OrderItem createOrderItem(final Item item, final Order order, final int orderPrice, final int count) {
-        return OrderItem.builder()
-                .item(item)
-                .order(order)
-                .orderPrice(orderPrice)
-                .count(count)
-                .build();
-    }
-
     public void addOrder(final Order order) {
         this.order = order;
     }

--- a/jpashop/src/main/java/jpabook/jpashop/domain/item/Album.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/item/Album.java
@@ -21,15 +21,4 @@ public class Album extends Item {
         this.artist = artist;
         this.etc = etc;
     }
-
-    public static Album createAlbum(final String name, final int price, final int stockQuantity, final String artist,
-                                    final String etc) {
-        return Album.builder()
-                .name(name)
-                .price(price)
-                .stockQuantity(stockQuantity)
-                .artist(artist)
-                .etc(etc)
-                .build();
-    }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/domain/item/Book.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/item/Book.java
@@ -21,15 +21,4 @@ public class Book extends Item {
         this.author = author;
         this.isbn = isbn;
     }
-
-    public static Book createBook(final String name, final int price, final int stockQuantity, final String author,
-                                  final String isbn) {
-        return Book.builder()
-                .name(name)
-                .price(price)
-                .stockQuantity(stockQuantity)
-                .author(author)
-                .isbn(isbn)
-                .build();
-    }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/domain/item/Item.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/item/Item.java
@@ -34,7 +34,7 @@ public abstract class Item {
     @ManyToMany(mappedBy = "items")
     private List<Category> categories = new ArrayList<>();
 
-    public Item(final String name, final int price, final int stockQuantity) {
+    protected Item(final String name, final int price, final int stockQuantity) {
         this.name = name;
         this.price = price;
         this.stockQuantity = stockQuantity;

--- a/jpashop/src/main/java/jpabook/jpashop/domain/item/Movie.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/item/Movie.java
@@ -21,15 +21,4 @@ public class Movie extends Item {
         this.director = director;
         this.actor = actor;
     }
-
-    public static Movie createMovie(final String name, final int price, final int stockQuantity, final String director,
-                              final String actor) {
-        return Movie.builder()
-                .name(name)
-                .price(price)
-                .stockQuantity(stockQuantity)
-                .director(director)
-                .actor(actor)
-                .build();
-    }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/domain/order/Order.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/order/Order.java
@@ -63,14 +63,6 @@ public class Order {
         delivery.addOrder(this);
     }
 
-    public static Order createOrder(final Member member, final Delivery delivery, final OrderStatus status) {
-        return Order.builder()
-                .member(member)
-                .delivery(delivery)
-                .status(status)
-                .build();
-    }
-
     public void addOrderItem(final OrderItem orderItem) {
         orderItems.add(orderItem);
         orderItem.addOrder(this);


### PR DESCRIPTION
## 설명
무분별하게 사용하던 빌더 + 정적 팩토리 메소드 패턴을 사용하지 않아도 되는 부분에선 삭제함

## 개선한 부분
- Item 및 하위 상속 도메인들에 대해 정적 팩토리 메소드를 삭제
- Order, Delivery, Member, OrderItem에서 정적 팩토리 메소드 삭제
- Category는 계층형 테이블 구조로, 부모와 자식의 구분이 필요하여 정적 팩토리 메소드 패턴은 삭제하지 않음
  하지만, 후에 변경될 요지가 있다.

## 이후
정적 팩토리 메소드 패턴은 인스턴스를 생서할때 검증할 값이 있거나, 특정 다른 로직이 필요한 경우 그때 추가해도 늦지 않을듯 하다


resolve #13 