### PR TITLE
feat: 상품 등록, 조회, 전체조회 기능 추가

### DIFF
--- a/jpashop/src/main/java/jpabook/jpashop/domain/item/Item.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/item/Item.java
@@ -11,6 +11,7 @@ import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.ManyToMany;
 import jpabook.jpashop.domain.Category;
+import jpabook.jpashop.exception.NotEnoughStockException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,7 +29,9 @@ public abstract class Item {
     private Long id;
 
     private String name;
+
     private int price;
+
     private int stockQuantity;
 
     @ManyToMany(mappedBy = "items")
@@ -38,5 +41,25 @@ public abstract class Item {
         this.name = name;
         this.price = price;
         this.stockQuantity = stockQuantity;
+    }
+
+    //==비즈니스 로직==//
+
+    /**
+     * 재고 증가
+     */
+    public void addStock(final int stockQuantity) {
+        this.stockQuantity += stockQuantity;
+    }
+
+    /**
+     * 재고 감소
+     */
+    public void removeStock(final int stockQuantity) {
+        int restStock = this.stockQuantity - stockQuantity;
+        if (restStock < 0) {
+            throw new NotEnoughStockException();
+        }
+        this.stockQuantity = restStock;
     }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/exception/NotEnoughStockException.java
+++ b/jpashop/src/main/java/jpabook/jpashop/exception/NotEnoughStockException.java
@@ -1,0 +1,24 @@
+package jpabook.jpashop.exception;
+
+public class NotEnoughStockException extends RuntimeException {
+
+    private static final String MESSAGE = "재고가 부족합니다.";
+
+    public NotEnoughStockException() {
+        super(MESSAGE);
+    }
+
+    public NotEnoughStockException(final String message, final Throwable cause) {
+        super(MESSAGE, cause);
+    }
+
+    public NotEnoughStockException(final Throwable cause) {
+        super(cause);
+    }
+
+    protected NotEnoughStockException(final String message, final Throwable cause, final boolean enableSuppression,
+                                      final boolean writableStackTrace) {
+        super(MESSAGE, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/jpashop/src/main/java/jpabook/jpashop/repository/ItemRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/ItemRepository.java
@@ -1,0 +1,37 @@
+package jpabook.jpashop.repository;
+
+import java.util.List;
+import javax.persistence.EntityManager;
+import jpabook.jpashop.domain.item.Item;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ItemRepository {
+
+    private final EntityManager entityManager;
+
+    @Autowired
+    public ItemRepository(final EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    public void save(final Item item) {
+        if (item.getId() == null) {
+            entityManager.persist(item);
+            return;
+        }
+        // 이미 영속성 컨텍스트에 존재하는 객체라면 기존에 있던 데이터에 변경사항만 추가한다.
+        // 만약 영속성 컨텍스트에서 엔티티를 조회할 수 없다면 새로 생성하고 병합한다.
+        entityManager.merge(item);
+    }
+
+    public Item findById(final Long id) {
+        return entityManager.find(Item.class, id);
+    }
+
+    public List<Item> findAll() {
+        return entityManager.createQuery("select i from Item i", Item.class)
+                .getResultList();
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/service/ItemService.java
+++ b/jpashop/src/main/java/jpabook/jpashop/service/ItemService.java
@@ -1,0 +1,32 @@
+package jpabook.jpashop.service;
+
+import java.util.List;
+import jpabook.jpashop.domain.item.Item;
+import jpabook.jpashop.repository.ItemRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class ItemService {
+
+    private final ItemRepository itemRepository;
+
+    public ItemService(final ItemRepository itemRepository) {
+        this.itemRepository = itemRepository;
+    }
+
+    @Transactional
+    public void saveItem(final Item item) {
+        itemRepository.save(item);
+    }
+
+    public List<Item> findItems() {
+        return itemRepository.findAll();
+    }
+
+    public Item findById(final Long itemId) {
+        return itemRepository.findById(itemId);
+    }
+
+}

--- a/jpashop/src/test/java/jpabook/jpashop/domain/item/ItemTest.java
+++ b/jpashop/src/test/java/jpabook/jpashop/domain/item/ItemTest.java
@@ -1,7 +1,9 @@
 package jpabook.jpashop.domain.item;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import jpabook.jpashop.exception.NotEnoughStockException;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class ItemTest {
@@ -15,7 +17,7 @@ class ItemTest {
         book.addStock(100);
 
         // then
-        Assertions.assertThat(book.getStockQuantity()).isEqualTo(100);
+        assertThat(book.getStockQuantity()).isEqualTo(100);
     }
 
     @Test
@@ -28,7 +30,7 @@ class ItemTest {
         book.removeStock(100);
 
         // then
-        Assertions.assertThat(book.getStockQuantity()).isEqualTo(0);
+        assertThat(book.getStockQuantity()).isEqualTo(0);
     }
 
     @Test
@@ -37,7 +39,7 @@ class ItemTest {
         Book book = Book.builder().build();
 
         // then
-        Assertions.assertThatThrownBy(() -> book.removeStock(100))
+        assertThatThrownBy(() -> book.removeStock(100))
                 .isInstanceOf(NotEnoughStockException.class);
     }
 }

--- a/jpashop/src/test/java/jpabook/jpashop/domain/item/ItemTest.java
+++ b/jpashop/src/test/java/jpabook/jpashop/domain/item/ItemTest.java
@@ -1,0 +1,43 @@
+package jpabook.jpashop.domain.item;
+
+import jpabook.jpashop.exception.NotEnoughStockException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ItemTest {
+
+    @Test
+    void addStock() {
+        // given
+        Book book = Book.builder().build();
+
+        // when
+        book.addStock(100);
+
+        // then
+        Assertions.assertThat(book.getStockQuantity()).isEqualTo(100);
+    }
+
+    @Test
+    void removeStock() {
+        // given
+        Book book = Book.builder().build();
+
+        // when
+        book.addStock(100);
+        book.removeStock(100);
+
+        // then
+        Assertions.assertThat(book.getStockQuantity()).isEqualTo(0);
+    }
+
+    @Test
+    void removeStock_exception_underZeroQuantity() {
+        // given
+        Book book = Book.builder().build();
+
+        // then
+        Assertions.assertThatThrownBy(() -> book.removeStock(100))
+                .isInstanceOf(NotEnoughStockException.class);
+    }
+}

--- a/jpashop/src/test/java/jpabook/jpashop/repository/ItemRepositoryTest.java
+++ b/jpashop/src/test/java/jpabook/jpashop/repository/ItemRepositoryTest.java
@@ -1,0 +1,62 @@
+package jpabook.jpashop.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import jpabook.jpashop.domain.item.Album;
+import jpabook.jpashop.domain.item.Book;
+import jpabook.jpashop.domain.item.Item;
+import jpabook.jpashop.domain.item.Movie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+public class ItemRepositoryTest {
+
+    @Autowired
+    TestEntityManager testEntityManager;
+
+    ItemRepository itemRepository;
+
+    Album album;
+    Book book;
+    Movie movie;
+
+    @BeforeEach
+    void setUp() {
+        itemRepository = new ItemRepository(testEntityManager.getEntityManager());
+        album = Album.builder()
+                .name("album")
+                .build();
+        book = Book.builder()
+                .name("book")
+                .build();
+        movie = Movie.builder()
+                .name("movie").build();
+
+        itemRepository.save(album);
+        itemRepository.save(book);
+        itemRepository.save(movie);
+    }
+
+    @Test
+    void findById() {
+        // when
+        Item item = itemRepository.findById(album.getId());
+
+        // then
+        assertThat(item).isEqualTo(album);
+    }
+
+    @Test
+    void finaAll() {
+        // when
+        List<Item> items = itemRepository.findAll();
+
+        // then
+        assertThat(items).containsExactly(album, book, movie);
+    }
+}

--- a/jpashop/src/test/java/jpabook/jpashop/service/ItemServiceTest.java
+++ b/jpashop/src/test/java/jpabook/jpashop/service/ItemServiceTest.java
@@ -1,0 +1,60 @@
+package jpabook.jpashop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import jpabook.jpashop.domain.item.Album;
+import jpabook.jpashop.domain.item.Book;
+import jpabook.jpashop.domain.item.Item;
+import jpabook.jpashop.domain.item.Movie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class ItemServiceTest {
+
+    @Autowired
+    ItemService itemService;
+
+    Album album;
+
+    Book book;
+
+    Movie movie;
+
+    @BeforeEach
+    void setUp() {
+
+        album = Album.builder()
+                .name("album")
+                .build();
+        book = Book.builder()
+                .name("book")
+                .build();
+        movie = Movie.builder()
+                .name("movie").build();
+
+        itemService.saveItem(album);
+        itemService.saveItem(book);
+        itemService.saveItem(movie);
+    }
+
+    @Test
+    void findItems() {
+        // when
+        List<Item> items = itemService.findItems();
+
+        // then
+        assertThat(items).containsExactly(album, book, movie);
+    }
+
+    @Test
+    void findById() {
+        // then
+        assertThat(album).isEqualTo(itemService.findById(album.getId()));
+    }
+}


### PR DESCRIPTION
## 설명
Item을 상속받는 상품에 대한 등록, 조회, 전체조회 기능을 추가함

- 수정 기능은 구현하지 않음

## 세부 기능 요구사항

## 어려웠던 부분
현재 프로젝트는 Spring Data Jpa가 아닌 Jpa를 직접 사용하고 있다.

@DataJpaTest를 사용할때 Repository의 EntityManager 필드에 빈이 주입이 되지 않아

TestEntityManager를 주입받아 해결하였음

resolve #18 